### PR TITLE
[Client] 알람 모달 스타일 수정

### DIFF
--- a/apps/client/src/components/alarmModal/style.ts
+++ b/apps/client/src/components/alarmModal/style.ts
@@ -18,6 +18,7 @@ export const Wrapper = styled.div`
   align-items: center;
   box-shadow: 0 0.25rem 0.5rem 0 rgba(144, 116, 72, 0.5);
   border-radius: 0.625rem;
+  z-index: 2;
 `;
 
 export const CoinWrapper = styled.div`


### PR DESCRIPTION
## 개요 💡

> 메인페이지에서 다른 요소와 알람 모달이 겹치는 이슈 발생

## 작업내용 ⌨️

> 알람 모달의 z-index 지정
<img width="1680" alt="스크린샷 2024-01-25 14 22 26" src="https://github.com/lucky-pocket/luckyPocket-front/assets/103751430/0cc6daa7-492a-4d29-aac6-01a25549e0c5">

<img width="1680" alt="스크린샷 2024-01-25 14 22 31" src="https://github.com/lucky-pocket/luckyPocket-front/assets/103751430/ae2aeb55-8c89-401c-80a4-f4f01bf515bf">
