### PR TITLE
[Client] useUserSearch 변경

### DIFF
--- a/apps/client/src/pageContainer/SearchPage/index.tsx
+++ b/apps/client/src/pageContainer/SearchPage/index.tsx
@@ -25,8 +25,10 @@ export default function Search() {
   const { searchUser, setSearchUser } = useSearchedUsersState();
   const { searchedUsers, setSearchedUsers } = useSearchedUsersState();
 
-  const { data } = useQuery<{ users: UsersType[] }>(['getUserSearch'], () =>
-    useUserSearch(searchUser)
+  const userSearchResult = useUserSearch(searchUser);
+  const { data } = useQuery<{ users: UsersType[] }>(
+    ['getUserSearch'],
+    () => userSearchResult
   );
 
   const handleSearchUser = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 개요 💡

> useUserSearch가 useQuery의 콜백 함수 내부에서 호출되어 React Hook 규칙에 위배됨

## 작업내용 ⌨️

> useUserSearch가 useQuery의 콜백 함수 내부에서 호출되지 않도록 변경


