### PR TITLE
[Client] 유저 검색 리스트 스타일 수정

### DIFF
--- a/apps/client/src/components/searchUserList/style.ts
+++ b/apps/client/src/components/searchUserList/style.ts
@@ -7,6 +7,7 @@ export const UserListWrapper = styled.div`
   flex-direction: column;
   gap: 1rem;
   overflow: scroll;
+  padding-bottom: 3.75rem;
   &::-webkit-scrollbar {
     display: none;
   }
@@ -14,7 +15,7 @@ export const UserListWrapper = styled.div`
 
 export const BackgroundFilter = styled.div`
   width: 100%;
-  height: 5.625rem;
+  height: 3.8rem;
   position: absolute;
   bottom: 0;
   background: linear-gradient(0, #f2ede5 3.22%, rgba(242, 237, 229, 0) 94.49%);


### PR DESCRIPTION
## 개요 💡

> 유저 검색시 맨 밑이 필터에 가려서 선택이 되지 않는 이슈 발생

## 작업내용 ⌨️

> 리스트 전체에 padding-bottom을 적용하고 필터의 height를 조정했습니다.
<img width="1679" alt="image" src="https://github.com/lucky-pocket/luckyPocket-front/assets/103751430/62c81029-8541-4170-b54d-c1a13dce8aaf">
