### PR TITLE
[Client] 사용자 role에 따른 이름 처리

### DIFF
--- a/apps/client/src/components/searchUserList/index.tsx
+++ b/apps/client/src/components/searchUserList/index.tsx
@@ -31,13 +31,17 @@ const SearchUserList = ({ searchedUsers }: SearchUserListProps) => {
     <S.UserListWrapper>
       {searchedUsers
         .filter((item) => decodedObject.userId !== item.userId)
-        .map(({ userId, grade, class: userClass, name }) => (
+        .map(({ userId, grade, class: userClass, name, userType }) => (
           <SearchUserItem
             key={userId}
             isClicked={selectedId === userId}
             onClick={() => handleItemClick(userId, name)}
           >
-            {grade}학년 {userClass}반 {name}
+            {userType === 'GRADUATE'
+              ? `졸업생 ${name}`
+              : userType === 'TEACHER'
+              ? `${name} 선생님`
+              : `${grade}학년 ${userClass}반 ${name}`}
           </SearchUserItem>
         ))}
       <S.BackgroundFilter />

--- a/apps/client/src/components/searchUserList/style.ts
+++ b/apps/client/src/components/searchUserList/style.ts
@@ -7,6 +7,7 @@ export const UserListWrapper = styled.div`
   flex-direction: column;
   gap: 1rem;
   overflow: scroll;
+  padding-bottom: 3.75rem;
   &::-webkit-scrollbar {
     display: none;
   }
@@ -14,7 +15,7 @@ export const UserListWrapper = styled.div`
 
 export const BackgroundFilter = styled.div`
   width: 100%;
-  height: 5.625rem;
+  height: 3.8rem;
   position: absolute;
   bottom: 0;
   background: linear-gradient(0, #f2ede5 3.22%, rgba(242, 237, 229, 0) 94.49%);

--- a/apps/client/src/components/userCard/index.tsx
+++ b/apps/client/src/components/userCard/index.tsx
@@ -33,7 +33,11 @@ const UserCard: React.FC<Props> = ({ user, rank, selectedStandard }) => {
           <S.Person>
             <S.Name>{user.name}</S.Name>
             <S.Class>
-              {user.grade}학년 {user.class}반
+              {user.userType === 'GRADUATE'
+                ? '졸업생'
+                : user.userType === 'TEACHER'
+                ? '선생님'
+                : `${user.grade}학년 ${user.class}반`}
             </S.Class>
           </S.Person>
           <S.Amount>


### PR DESCRIPTION
## 개요 💡

> 졸업생, 선생님은 학번이 없음

## 작업내용 ⌨️

> userType을 검사해 졸업생과 선생님은 반, 번이 아니라 역할로 뜨도록 변경
<img width="210" alt="image" src="https://github.com/lucky-pocket/luckyPocket-front/assets/103751430/27fb029a-e81c-44b9-bc07-426da3c6552f">
<img width="1680" alt="image" src="https://github.com/lucky-pocket/luckyPocket-front/assets/103751430/bdb6c4ca-596b-4c57-80d3-446d0ec2ee19">
