### PR TITLE
[Client] 알람 모달 스타일 수정

### DIFF
--- a/apps/client/src/components/alarmModal/style.ts
+++ b/apps/client/src/components/alarmModal/style.ts
@@ -22,10 +22,10 @@ export const Wrapper = styled.div`
 `;
 
 export const CoinWrapper = styled.div`
-  height: 3.5rem;
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  margin: 16px 0;
 `;
 
 export const CoinCount = styled.span`
@@ -42,7 +42,7 @@ export const AlarmWrapper = styled.div`
 `;
 
 export const AlarmItem = styled.div`
-  width: 21.5rem;
+  width: 21.2rem;
   padding: 0.625rem 1.25rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 개요 💡

> 알람 모달 스타일 이슈

## 작업내용 ⌨️

> 아이템 width를 줄이고 CoinWrapper의 상하 margin을 지정했습니다.
<img width="375" alt="image" src="https://github.com/lucky-pocket/luckyPocket-front/assets/103751430/3b9a349c-e4a7-4722-b65f-78be12d4c3d1">
