### PR TITLE
[Client] 복주머니 보내기 수 제한 모달 추가 및 요청 로직 변경

### DIFF
--- a/apps/client/src/components/index.ts
+++ b/apps/client/src/components/index.ts
@@ -13,3 +13,4 @@ export { default as SearchBar } from './searchBar';
 export { default as FilterModal } from './filterModal';
 export { default as RevealModal } from './revealModal';
 export { default as MainContent } from './mainContent';
+export { default as PocketLimitModal } from './pocketLimitModal';

--- a/apps/client/src/components/pocketLimitModal/index.tsx
+++ b/apps/client/src/components/pocketLimitModal/index.tsx
@@ -1,0 +1,47 @@
+import { usePocketLimitModalState, usePocketSendState } from 'client/stores';
+import * as S from './style';
+import { useRouter } from 'next/navigation';
+
+interface propsType {
+  modalRef: React.ForwardedRef<HTMLDivElement>;
+  modalOutSideClick: (e: any) => void;
+}
+
+const PocketLimitModal = ({ modalRef, modalOutSideClick }: propsType) => {
+  const { setPocketLimitModal } = usePocketLimitModalState();
+  const { reset } = usePocketSendState();
+  const router = useRouter();
+
+  return (
+    <S.Container
+      ref={modalRef}
+      onClick={(e) => {
+        modalOutSideClick(e);
+        reset();
+        router.push('/search');
+      }}
+    >
+      <S.Wrapper>
+        <S.TextWrapper>
+          <S.Title>이런 편지지를 다 썼어요!</S.Title>
+          <S.Content>
+            하루에 한 유저에게 보낼 수 있는 편지는 최대 5장이에요.
+          </S.Content>
+        </S.TextWrapper>
+        <S.ButtonContainer>
+          <button
+            onClick={() => {
+              setPocketLimitModal(false);
+              reset();
+              router.push('/search');
+            }}
+          >
+            확인
+          </button>
+        </S.ButtonContainer>
+      </S.Wrapper>
+    </S.Container>
+  );
+};
+
+export default PocketLimitModal;

--- a/apps/client/src/components/pocketLimitModal/index.tsx
+++ b/apps/client/src/components/pocketLimitModal/index.tsx
@@ -1,4 +1,8 @@
-import { usePocketLimitModalState, usePocketSendState } from 'client/stores';
+import {
+  usePocketLimitModalState,
+  usePocketSendState,
+  useSearchedUsersState,
+} from 'client/stores';
 import * as S from './style';
 import { useRouter } from 'next/navigation';
 
@@ -10,6 +14,7 @@ interface propsType {
 const PocketLimitModal = ({ modalRef, modalOutSideClick }: propsType) => {
   const { setPocketLimitModal } = usePocketLimitModalState();
   const { reset } = usePocketSendState();
+  const { setSelectedId } = useSearchedUsersState();
   const router = useRouter();
 
   return (
@@ -18,6 +23,7 @@ const PocketLimitModal = ({ modalRef, modalOutSideClick }: propsType) => {
       onClick={(e) => {
         modalOutSideClick(e);
         reset();
+        setSelectedId(null);
         router.push('/search');
       }}
     >
@@ -33,6 +39,7 @@ const PocketLimitModal = ({ modalRef, modalOutSideClick }: propsType) => {
             onClick={() => {
               setPocketLimitModal(false);
               reset();
+              setSelectedId(null);
               router.push('/search');
             }}
           >

--- a/apps/client/src/components/pocketLimitModal/style.ts
+++ b/apps/client/src/components/pocketLimitModal/style.ts
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  position: absolute;
+  width: 38rem;
+  height: 100vh;
+  background-color: rgba(30, 29, 27, 0.5);
+  top: 0;
+  left: 0;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Wrapper = styled.div`
+  width: 30rem;
+  height: 9.8125rem;
+  background-color: ${({ theme }) => theme.color.ivory['010']};
+  border-radius: 0.625rem;
+  padding: 1.5rem;
+  font-size: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+`;
+
+export const Title = styled.h1`
+  font-size: 1.125rem;
+  color: ${({ theme }) => theme.color.gray['090']};
+`;
+
+export const Content = styled.p`
+  color: ${({ theme }) => theme.color.error['050']};
+`;
+
+export const ButtonContainer = styled.div`
+  text-align: end;
+
+  button {
+    font-size: 1.125rem;
+    padding: 0.25rem;
+    color: ${({ theme }) => theme.color.gray['050']};
+  }
+`;

--- a/apps/client/src/pageContainer/CompletePage/index.tsx
+++ b/apps/client/src/pageContainer/CompletePage/index.tsx
@@ -3,27 +3,16 @@
 import { Header } from 'client/components';
 import * as S from './style';
 import { CompletePocket } from 'client/assets';
-import { usePocketSendState, useSearchedUsersState } from 'client/stores';
-import { API } from 'api/client/API';
-import { pocketUrl } from 'api/client';
+import { usePocketSendState } from 'client/stores';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
 export default function Complete() {
-  const { receiverName, pocketSend, reset } = usePocketSendState();
-  const { setSelectedId } = useSearchedUsersState();
+  const { receiverName } = usePocketSendState();
   const router = useRouter();
 
-  const sendPocket = async () => {
-    await API.post(pocketUrl.postPocket(), pocketSend);
-  };
-
   useEffect(() => {
-    sendPocket().then(() => {
-      reset();
-      setSelectedId(null);
-      setTimeout(() => router.push('/'), 3000);
-    });
+    setTimeout(() => router.push('/'), 2000);
   }, []);
 
   return (

--- a/apps/client/src/pageContainer/SendPage/style.tsx
+++ b/apps/client/src/pageContainer/SendPage/style.tsx
@@ -137,3 +137,48 @@ export const ScopeButton = styled.button<{ isClicked: boolean }>`
       background-color: ${theme.color.sub.brown['100']};
     `}
 `;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 92vh;
+  gap: 1.25rem;
+`;
+
+export const Button = styled.button`
+  ${({ theme }) => theme.typo.title.small}
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  width: 8rem;
+  height: 2.875rem;
+  border-radius: 0.625rem;
+  color: ${({ theme }) => theme.color.gray['060']};
+  line-height: 0;
+
+  svg {
+    margin-bottom: 0.125rem;
+  }
+`;
+
+export const BeforeButton = styled(Button)`
+  border: 0.0625rem solid ${({ theme }) => theme.color.gray['050']};
+`;
+
+export const NextButton = styled(Button)`
+  background: ${({ theme }) => theme.color.sub.brown['100']};
+  color: ${({ theme }) => theme.color.ivory['010']};
+
+  svg {
+    transform: rotate(180deg);
+  }
+
+  :disabled {
+    cursor: not-allowed;
+    color: ${({ theme }) => theme.color.gray['060']};
+    background: ${({ theme }) => theme.color.gray['030']};
+  }
+`;

--- a/apps/client/src/stores/index.ts
+++ b/apps/client/src/stores/index.ts
@@ -1,2 +1,3 @@
 export { default as useSearchedUsersState } from './useSearchedUsersStore';
 export { default as usePocketSendState } from './usePocketSendStore';
+export { default as usePocketLimitModalState } from './usePocketLimitModalStore';

--- a/apps/client/src/stores/usePocketLimitModalStore.ts
+++ b/apps/client/src/stores/usePocketLimitModalStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface PocketSendStore {
+  pocketLimitModal: boolean;
+  setPocketLimitModal: (value: boolean) => void;
+}
+
+export const usePocketLimitModalState = create<PocketSendStore>((set) => ({
+  pocketLimitModal: true,
+  setPocketLimitModal: (value: boolean) => set({ pocketLimitModal: value }),
+}));
+
+export default usePocketLimitModalState;

--- a/apps/client/src/stores/usePocketLimitModalStore.ts
+++ b/apps/client/src/stores/usePocketLimitModalStore.ts
@@ -6,7 +6,7 @@ interface PocketSendStore {
 }
 
 export const usePocketLimitModalState = create<PocketSendStore>((set) => ({
-  pocketLimitModal: true,
+  pocketLimitModal: false,
   setPocketLimitModal: (value: boolean) => set({ pocketLimitModal: value }),
 }));
 


### PR DESCRIPTION
## 개요 💡

> 한 사람이 동일한 유저에서 최대 5개의 복주머니를 보낼 수 있는 제한 추가

## 작업내용 ⌨️

> - 복주머니 전송을 /send 페이지에서 다음 버튼을 누를 때 요청
> - 요청시 성공시 /complete 이동, 실패시 확인 모달 출력
> - /complete 페이지에서 2초 이후 메인페이지로 이동
> - 모달을 끄면 입력한 내용들을 삭제하고 /search로 이동
<img width="1680" alt="image" src="https://github.com/lucky-pocket/luckyPocket-front/assets/103751430/6479e06c-fd0d-43f3-b050-1edc3bbaef44">
