### PR TITLE
[Client] (core)Fix refresh logic && (sub)Add rewrites

### DIFF
--- a/apps/client/next.config.js
+++ b/apps/client/next.config.js
@@ -7,6 +7,12 @@ const nextConfig = {
     CLIENT_API_URL: process.env.CLIENT_API_URL,
     NEXT_PUBLIC_GA_ID: process.env.NEXT_PUBLIC_GA_ID,
   },
+  rewrites: async () => [
+    {
+      source: '/api/:path*',
+      destination: `${process.env.NEXT_PUBLIC_CLIENT_API_URL}/:path*`,
+    },
+  ],
 };
 
 module.exports = nextConfig;

--- a/apps/client/src/app/complete/page.tsx
+++ b/apps/client/src/app/complete/page.tsx
@@ -1,18 +1,9 @@
 'use client';
 
 import { CompletePage } from 'client/pageContainer';
-import React, { useEffect } from 'react';
-import { redirect } from 'next/navigation';
+import React from 'react';
 
 export default function Complete() {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
-
   return (
     <div>
       <CompletePage />

--- a/apps/client/src/app/complete/page.tsx
+++ b/apps/client/src/app/complete/page.tsx
@@ -9,7 +9,7 @@ export default function Complete() {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
 

--- a/apps/client/src/app/game/page.tsx
+++ b/apps/client/src/app/game/page.tsx
@@ -9,7 +9,7 @@ export default function Game() {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
 

--- a/apps/client/src/app/game/page.tsx
+++ b/apps/client/src/app/game/page.tsx
@@ -1,17 +1,8 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { GamePage } from 'client/pageContainer';
-import { redirect } from 'next/navigation';
 
 export default function Game() {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
-
   return <GamePage />;
 }

--- a/apps/client/src/app/inspection/page.tsx
+++ b/apps/client/src/app/inspection/page.tsx
@@ -1,17 +1,7 @@
 'use client';
 
 import { InspectionPage } from 'client/pageContainer';
-import React, { useEffect } from 'react';
-import { redirect } from 'next/navigation';
 
 export default function Inspection() {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
-
   return <InspectionPage />;
 }

--- a/apps/client/src/app/inspection/page.tsx
+++ b/apps/client/src/app/inspection/page.tsx
@@ -9,7 +9,7 @@ export default function Inspection() {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
 

--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -1,16 +1,8 @@
 'use client';
 
-import React, { useEffect } from 'react';
-import { redirect } from 'next/navigation';
+import React from 'react';
 import { MainPage } from 'client/pageContainer';
 
 export default function Main() {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
   return <MainPage />;
 }

--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -9,7 +9,7 @@ export default function Main() {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
   return <MainPage />;

--- a/apps/client/src/app/rank/page.tsx
+++ b/apps/client/src/app/rank/page.tsx
@@ -9,7 +9,7 @@ export default function Rank() {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
 

--- a/apps/client/src/app/rank/page.tsx
+++ b/apps/client/src/app/rank/page.tsx
@@ -1,17 +1,7 @@
 'use client';
 
 import { RankPage } from 'client/pageContainer';
-import React, { useEffect } from 'react';
-import { redirect } from 'next/navigation';
 
 export default function Rank() {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
-
   return <RankPage />;
 }

--- a/apps/client/src/app/search/page.tsx
+++ b/apps/client/src/app/search/page.tsx
@@ -9,7 +9,7 @@ export default function Search() {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
 

--- a/apps/client/src/app/search/page.tsx
+++ b/apps/client/src/app/search/page.tsx
@@ -1,17 +1,7 @@
 'use client';
 
 import { SearchPage } from 'client/pageContainer';
-import React, { useEffect } from 'react';
-import { redirect } from 'next/navigation';
 
 export default function Search() {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
-
   return <SearchPage />;
 }

--- a/apps/client/src/app/send/page.tsx
+++ b/apps/client/src/app/send/page.tsx
@@ -1,16 +1,7 @@
 'use client';
 
-import { useEffect } from 'react';
-import { redirect } from 'next/navigation';
 import { SendPage } from 'client/pageContainer';
 export default function Send() {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
   return (
     <div>
       <SendPage />

--- a/apps/client/src/app/send/page.tsx
+++ b/apps/client/src/app/send/page.tsx
@@ -8,7 +8,7 @@ export default function Send() {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
   return (

--- a/apps/client/src/app/users/[userId]/page.tsx
+++ b/apps/client/src/app/users/[userId]/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import React, { useEffect } from 'react';
-import { redirect } from 'next/navigation';
 import { UserPage } from 'client/pageContainer';
 
 interface UserPageProps {
@@ -9,13 +7,6 @@ interface UserPageProps {
 }
 
 export default async function User({ params: { userId } }: UserPageProps) {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
   return (
     <div>
       <UserPage userId={userId} />

--- a/apps/client/src/app/users/[userId]/page.tsx
+++ b/apps/client/src/app/users/[userId]/page.tsx
@@ -13,7 +13,7 @@ export default async function User({ params: { userId } }: UserPageProps) {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
   return (

--- a/apps/client/src/app/write/page.tsx
+++ b/apps/client/src/app/write/page.tsx
@@ -1,17 +1,7 @@
 'use client';
 
 import { WritePage } from 'client/pageContainer';
-import React, { useEffect } from 'react';
-import { redirect } from 'next/navigation';
 
 export default function Write() {
-  useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-
-    if (!accessToken) {
-      // redirect('/auth/signin');
-    }
-  }, []);
-
   return <WritePage />;
 }

--- a/apps/client/src/app/write/page.tsx
+++ b/apps/client/src/app/write/page.tsx
@@ -9,7 +9,7 @@ export default function Write() {
     const accessToken = localStorage.getItem('accessToken');
 
     if (!accessToken) {
-      redirect('/auth/signin');
+      // redirect('/auth/signin');
     }
   }, []);
 

--- a/packages/api/client/API.ts
+++ b/packages/api/client/API.ts
@@ -23,7 +23,7 @@ const waitRefreshEnd = () =>
 
 API.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
-    let accessToken = localStorage.getItem('accessToken');
+    const accessToken = localStorage.getItem('accessToken');
 
     config.headers['Authorization'] = accessToken
       ? `Bearer ${accessToken}`
@@ -39,6 +39,7 @@ API.interceptors.response.use(
     if (response.config.url === authUrl.postRefresh()) {
       isRefreshing = false;
     }
+
     if (response.status >= 200 && response.status <= 300) {
       return response;
     }
@@ -78,7 +79,9 @@ API.interceptors.response.use(
           })
           .catch((error) => {
             console.error('Error occurred during token refresh:', error);
+
             isRefreshing = false;
+
             throw error;
           });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,15 +160,6 @@ importers:
         specifier: ^5
         version: 5.0.2
 
-  packages/ui:
-    dependencies:
-      common:
-        specifier: workspace:^
-        version: link:../common
-      typescript:
-        specifier: 5.0.4
-        version: 5.0.4
-
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -3753,12 +3744,6 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
     dev: true
-
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
-    hasBin: true
-    dev: false
 
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}


### PR DESCRIPTION
## 개요 💡

> 적절하지 않게 동작하는 token refresh 로직을 수정 하였습니다.

## core 작업내용 ⌨️

기존 refresh 로직의 문제점은 아래 사진으로 보이는바와 같습니다.

![image](https://github.com/lucky-pocket/luckyPocket-front/assets/106712562/1b2621af-c641-4a58-b880-2335e9edbe7e)

refresh 까지는 정상적으로 작동하지만, 이후의 과정에서 권한이 없다는 오류가 생깁니다. 즉, 비동기 처리에 관련된 문제로 보여집니다.
때문에 client에서 직접 새로고침을 하여야 정상적으로 작동했습니다.

이를 아래와 같은 방법으로 해결했습니다.
- interceptors.response에 response status로 컨트롤하는 refresh 로직을 삽입하여 문제 없이 작동할 수 있도록 했습니다.
- 기존에 있던 axios instance로 중복되는 config를 줄였습니다.
- isRefreshed + refreshPromise로 모든 요청이 정상적으로 토큰을 가져갈 수 있도록 했습니다.
- 변수 차단을 위해 local storage에 access token 필드가 존재하지 않더라도 새로 로그인하지 않고 정상 작동하도록 했습니다.

아래는 문제가 해결된 영상입니다.

https://github.com/lucky-pocket/luckyPocket-front/assets/106712562/725be135-8bc7-43d3-95a0-e810244e3e46

## sub 작업내용 ⌨️
refresh token 쿠키 same site 옵션이 lax이기 때문에 다른 오리진에서는 사용이 불가능한 이슈가 있었습니다. 즉, 로컬에서는 테스트가 불가능한 것입니다.

이를 해결하기 위해 테스트서버를 띄우는 방법도 있지만, 일단은 현재 상황에서도 로컬에서 테스트가 가능하게 하기 위한 구성을 추가했습니다.

nextjs의 서버사이드메소드에서 호출하는 request는 브라우저가 아닌, 서버에서 호출하므로 CORS가 발생하지 않는다고 합니다. 따라서 해당 이슈를 우회할 수 있습니다.

- rewrites 옵션 추가 + axios instance의 baseUrl 옵션으로 이 문제를 해결했습니다.

---

## 로컬에서 개발 방법
1. https://www.lucky-pocket.site/ 에서 로그인합니다.
2. refresh token을 복사합니다.
3. localhost에 붙여넣기합니다.

변경사항에 문제가 있거나, 본래 의도와 다르게 동작한다면 피드백 부탁드립니다!