### PR TITLE
[Client] Fix rewrites

### DIFF
--- a/apps/client/next.config.js
+++ b/apps/client/next.config.js
@@ -10,7 +10,7 @@ const nextConfig = {
   rewrites: async () => [
     {
       source: '/api/:path*',
-      destination: `${process.env.NEXT_PUBLIC_CLIENT_API_URL}/:path*`,
+      destination: `${process.env.NEXT_PUBLIC_CLIENT_API_URL}:path*`,
     },
   ],
 };

--- a/packages/api/client/API.ts
+++ b/packages/api/client/API.ts
@@ -5,7 +5,7 @@ let isRefreshing = false;
 let refreshPromise: Promise<any> | null = null;
 
 export const API = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_CLIENT_API_URL,
+  baseURL: '/api',
   headers: {
     'Content-Type': 'application/json',
   },
@@ -47,8 +47,11 @@ API.interceptors.response.use(
     return Promise.reject(response);
   },
   async (error) => {
-    if (error.config.url === authUrl.postRefresh()) {
+    if (error.config.url.includes(authUrl.postRefresh())) {
       isRefreshing = false;
+
+      location.href = '/auth/signin';
+
       return Promise.resolve(error);
     }
 
@@ -90,7 +93,7 @@ API.interceptors.response.use(
     }
 
     if (error.response && error.response.status === 500) {
-      window.location.href = '/error';
+      // window.location.href = '/error';
     }
 
     if (error.response && error.response.status === 504) {

--- a/packages/api/client/API.ts
+++ b/packages/api/client/API.ts
@@ -93,7 +93,7 @@ API.interceptors.response.use(
     }
 
     if (error.response && error.response.status === 500) {
-      // window.location.href = '/error';
+      window.location.href = '/error';
     }
 
     if (error.response && error.response.status === 504) {

--- a/packages/api/client/src/hooks/api/libs/requestUrlController.ts
+++ b/packages/api/client/src/hooks/api/libs/requestUrlController.ts
@@ -6,8 +6,8 @@ export const pocketUrl = {
 
 export const authUrl = {
   getAuth: (code: string) => `/auth/gauth?code=${code}`,
-  postLogout: () => 'auth/logout',
-  postRefresh: () => 'auth/refresh',
+  postLogout: () => '/auth/logout',
+  postRefresh: () => '/auth/refresh',
 };
 
 export const userMyUrl = {


### PR DESCRIPTION
## 개요 💡

> 배포 환경과 로컬에서의 rewrite가 다르게 되어 해당 이슈를 처리했습니다.

## 작업내용 ⌨️

현재 `fix/rewrites` 브랜치가 prod에 배포되어있는 상태입니다.

'/api'를 baseUrl로 사용하지 않는다면 네트워크 탭에 서버 요청 url이 노출됩니다.
https://api.lucky-pocket.site/blabla <- 와 같습니다.

현재는 아래 사진에서 보이는바와 같이 /api로 서버 url이 마스킹됩니다.
<img width="204" alt="image" src="https://github.com/lucky-pocket/luckyPocket-front/assets/106712562/7446c5d0-6e86-46bf-96b3-3300a9e40e7b">

이로 인해 보안성을 높일 수 있습니다.